### PR TITLE
Ceph-integration: fix the log config path.

### DIFF
--- a/etc/tendrl/tendrl.conf.sample
+++ b/etc/tendrl/tendrl.conf.sample
@@ -7,7 +7,7 @@ etcd_port = 2379
 etcd_connection = 0.0.0.0
 
 # Path to log file
-log_path = /var/log/tendrl/common.log
+log_cfg_path = /etc/tendrl/common_logging.yaml
 log_level = DEBUG
 
 


### PR DESCRIPTION
Fixed the logging config path of common in ceph_integration conf file.

tendrl-bug-id: Tendrl/ceph_integration#42