### PR TITLE
Fixes pool create and delete not working

### DIFF
--- a/tendrl/ceph_integration/manager/rpc.py
+++ b/tendrl/ceph_integration/manager/rpc.py
@@ -130,7 +130,8 @@ class EtcdRPC(object):
     def extract_flow_details(self, flow_name, definitions):
         namespace = flow_name.split(".flows.")[0]
         flow = definitions[namespace]['flows'][flow_name.split(".")[-1]]
-        return flow['atoms'], flow['pre_run'], flow['post_run'], flow['uuid']
+        return flow['atoms'], flow.get('pre_run', []),\
+            flow.get('post_run', []), flow['uuid']
 
 
 class EtcdThread(gevent.greenlet.Greenlet):


### PR DESCRIPTION
- Flow defined for pool create and delete did not contain any pre_run or post_run checks, the flow manager module expects pre_run, post_run checks, this patch makes it optional

tendrl-bug-id: Tendrl/ceph_integration#44
tendrl-bug-id: Tendrl/ceph_integration#45