### PR TITLE
Add preferred tags field to the flows

### DIFF
--- a/etc/create_sample_job.py
+++ b/etc/create_sample_job.py
@@ -7,8 +7,12 @@ job_id1 = str(uuid.uuid4())
 
 job = {
     "cluster_id": "49fa2adde8a6e98591f0f5cb4bc5f44d",
-    "run": "tendrl.gluster_integration.flows.create.CreatePool",
+    "run": "tendrl.ceph_integration.flows.create.CreatePool",
     "status": 'new',
+    "targeted_tags": [  # refer this field from the flow definition file
+        "ceph/mon",
+        "tendrl/integration/ceph"
+    ],
     "parameters": {
         "Pool.poolname": 'test',
         "Pool.pg_num": 1,

--- a/tendrl/ceph_integration/manager/tendrl_definitions_ceph.py
+++ b/tendrl/ceph_integration/manager/tendrl_definitions_ceph.py
@@ -6,6 +6,9 @@ namespace.tendrl.ceph_integration:
       atoms:
         - tendrl.ceph_integration.objects.Pool.atoms.create
       help: "Create Ceph Pool"
+      preferred_tags:
+        - "tendrl/integration/ceph"
+        - "ceph/mon"
       enabled: true
       inputs:
         mandatory:
@@ -51,6 +54,9 @@ namespace.tendrl.ceph_integration:
           atoms:
             - tendrl.ceph_integration.objects.Pool.atoms.delete
           help: "Delete Ceph Pool"
+          preferred_tags:
+            - "tendrl/integration/ceph"
+            - "ceph/mon"
           enabled: true
           inputs:
             mandatory:


### PR DESCRIPTION
This patch adds preferred tags field in the flow
definition file. This will be used during job
generation to target jobs at specific type of nodes.
Also the sample job file is modified to include
this

tendrl-bug-id: Tendrl/ceph-integration#81
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>