### PR TITLE
Packaging: Config file changes update and add auto version bump

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include AUTHORS
 include ChangeLog
+include requirements.txt
 exclude .gitignore
 exclude .gitreview
 graft systemd

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE
 include AUTHORS
 include ChangeLog
 include requirements.txt
+include version.py
 exclude .gitignore
 exclude .gitreview
 graft systemd

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME=tendrl-ceph-integration
 VERSION := $(shell PYTHONPATH=. python -c \
-             'import tendrl.ceph_integration; print tendrl.ceph_integration.__version__' \
+             'import version; print version.__version__' \
              | sed 's/\.dev[0-9]*//')
 RELEASE=1
 COMMIT := $(shell git rev-parse HEAD)
@@ -31,7 +31,7 @@ gitversion:
 	# Set version and release to the latest values from Git
 	$(eval VERSION := $(VERSION).dev$(GIT_RELEASE))
 	$(eval RELEASE := $(GIT_RELEASE).$(SHORTCOMMIT))
-	sed -i tendrl/ceph_integration/__init__.py \
+	sed -i version.py \
 	  -e "s/^__version__ = .*/__version__ = '$(VERSION)'/"
 	sed -i tendrl-ceph-integration.spec \
 	  -e "s/^Version: .*/Version: $(VERSION)/"

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,21 @@
-NAME = tendrl-ceph-integration
-VERSION=1.1
+NAME=tendrl-ceph-integration
+VERSION := $(shell PYTHONPATH=. python -c \
+             'import tendrl.ceph_integration; print tendrl.ceph_integration.__version__' \
+             | sed 's/\.dev[0-9]*//')
 RELEASE=1
+COMMIT := $(shell git rev-parse HEAD)
+SHORTCOMMIT := $(shell echo $(COMMIT) | cut -c1-7)
+GIT_RELEASE := $(shell git describe --tags --match 'v*' \
+                 | sed 's/^v//' \
+                 | sed 's/^[^-]*-//' \
+                 | sed 's/-.*//')
 
 all: srpm
 
 clean:
 	rm -rf dist/
 	rm -rf $(NAME)-$(VERSION).tar.gz
-	rm -rf $(NAME)-$(VERSION)-1.el7.src.rpm
+	rm -rf $(NAME)-$(VERSION)-$(RELEASE).el7.src.rpm
 
 dist:
 	python setup.py sdist \
@@ -19,4 +27,18 @@ srpm: dist
 rpm: dist
 	mock -r epel-7-x86_64 rebuild $(NAME)-$(VERSION)-$(RELEASE).el7.src.rpm --resultdir=. --define "dist .el7"
 
-.PHONY: dist rpm srpm
+gitversion:
+	# Set version and release to the latest values from Git
+	$(eval VERSION := $(VERSION).dev$(GIT_RELEASE))
+	$(eval RELEASE := $(GIT_RELEASE).$(SHORTCOMMIT))
+	sed -i tendrl/ceph_integration/__init__.py \
+	  -e "s/^__version__ = .*/__version__ = '$(VERSION)'/"
+	sed -i tendrl-ceph-integration.spec \
+	  -e "s/^Version: .*/Version: $(VERSION)/"
+	sed -i tendrl-ceph-integration.spec \
+	  -e "s/^Release: .*/Release: $(RELEASE)/"
+
+snapshot: gitversion srpm
+
+
+.PHONY: dist rpm srpm gitversion snapshot

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,107 @@
+import re
+from setuptools import Command
 from setuptools import find_packages
 from setuptools import setup
+import subprocess
+try:
+    # Python 2 backwards compat
+    from __builtin__ import raw_input as input
+except ImportError:
+    pass
+
+
+def extract_requirements(filename):
+    with open(filename, 'r') as requirements_file:
+        return [
+            x[:-1] for x in requirements_file.readlines()
+            if not x.startswith("#") and x[:-1] != ''
+        ]
+
+install_requires = extract_requirements('requirements.txt')
+
+
+def read_module_contents():
+    with open('tendrl/ceph_integration/__init__.py') as app_init:
+        return app_init.read()
+
+
+def read_spec_contents():
+    with open('tendrl-ceph-integration.spec') as spec:
+        return spec.read()
+
+module_file = read_module_contents()
+metadata = dict(re.findall("__([a-z]+)__\s*=\s*'([^']+)'", module_file))
+version = metadata['version']
+
+
+class BumpVersionCommand(Command):
+    """Bump the __version__ number and commit all changes."""
+
+    user_options = [('version=', 'v', 'version number to use')]
+
+    def initialize_options(self):
+        new_version = metadata['version'].split('.')
+        new_version[-1] = str(int(new_version[-1]) + 1)  # Bump the final part
+        self.version = ".".join(new_version)
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+
+        print('old version: %s  new version: %s' %
+              (metadata['version'], self.version))
+        try:
+            input('Press enter to confirm, or ctrl-c to exit >')
+        except KeyboardInterrupt:
+            raise SystemExit("\nNot proceeding")
+
+        old = "__version__ = '%s'" % metadata['version']
+        new = "__version__ = '%s'" % self.version
+        module_file = read_module_contents()
+        with open('tendrl/ceph_integration/__init__.py', 'w') as fileh:
+            fileh.write(module_file.replace(old, new))
+
+        old = 'Version: %s' % metadata['version']
+        new = 'Version: %s' % self.version
+        spec_file = read_spec_contents()
+        with open('tendrl-ceph-integration.spec', 'w') as fileh:
+            fileh.write(spec_file.replace(old, new))
+
+        # Commit everything with a standard commit message
+        cmd = ['git', 'commit', '-a', '-m', 'version %s' % self.version]
+        print(' '.join(cmd))
+        subprocess.check_call(cmd)
+
+
+class ReleaseCommand(Command):
+    """Tag and push a new release."""
+
+    user_options = [('sign', 's', 'GPG-sign the Git tag and release files')]
+
+    def initialize_options(self):
+        self.sign = False
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        # Create Git tag
+        tag_name = 'v%s' % version
+        cmd = ['git', 'tag', '-a', tag_name, '-m', 'version %s' % version]
+        if self.sign:
+            cmd.append('-s')
+        print(' '.join(cmd))
+        subprocess.check_call(cmd)
+
+        # Push Git tag to origin remote
+        cmd = ['git', 'push', 'origin', tag_name]
+        print(' '.join(cmd))
+        subprocess.check_call(cmd)
 
 setup(
     name="tendrl-ceph-integration",
-    version="1.2",
+    version=version,
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*",
                                     "tests"]),
     namespace_packages=['tendrl'],
@@ -12,9 +110,11 @@ setup(
     author_email="rkanade@redhat.com",
     license="LGPL-2.1+",
     zip_safe=False,
+    install_requires=install_requires,
     entry_points={
         'console_scripts': ['tendrl-ceph-integration = '
                             'tendrl.ceph_integration.manager:main'
                             ]
-    }
+    },
+    cmdclass={'bumpversion': BumpVersionCommand, 'release': ReleaseCommand},
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = extract_requirements('requirements.txt')
 
 
 def read_module_contents():
-    with open('tendrl/ceph_integration/__init__.py') as app_init:
+    with open('version.py') as app_init:
         return app_init.read()
 
 
@@ -59,7 +59,7 @@ class BumpVersionCommand(Command):
         old = "__version__ = '%s'" % metadata['version']
         new = "__version__ = '%s'" % self.version
         module_file = read_module_contents()
-        with open('tendrl/ceph_integration/__init__.py', 'w') as fileh:
+        with open('version.py', 'w') as fileh:
             fileh.write(module_file.replace(old, new))
 
         old = 'Version: %s' % metadata['version']

--- a/tendrl-ceph-integration.spec
+++ b/tendrl-ceph-integration.spec
@@ -63,5 +63,9 @@ py.test -v tendrl/ceph_integration/tests || :
 %{_sysconfdir}/tendrl/ceph-integration/ceph-integration.conf.yaml
 
 %changelog
-* Wed Oct 26 2016 Timothy Asir Jeyasingh <tjeyasin@redhat.com> - 1.1-1
+* Mon Jan 23 2017 Timothy Asir Jeyasingh <tjeyasin@redhat.com> - 1.1-1
+- Config file changes
+- Import ceph
+
+* Wed Oct 26 2016 Timothy Asir Jeyasingh <tjeyasin@redhat.com> - 0.0.1-1
 - Initial build.

--- a/tendrl-ceph-integration.spec
+++ b/tendrl-ceph-integration.spec
@@ -23,9 +23,6 @@ Tendrl bridge for Ceph Storage
 
 %prep
 %setup
-# Remove the requirements file to avoid adding into
-# distutils requiers_dist config
-rm -rf {test-,}requirements.txt
 
 # Remove bundled egg-info
 rm -rf %{name}.egg-info
@@ -35,12 +32,13 @@ rm -rf %{name}.egg-info
 
 %install
 %{__python} setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
-install -m  0755 --directory $RPM_BUILD_ROOT%{_var}/log/tendrl/ceph-integration
 install -m  0755  --directory $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/ceph-integration
+install -m  0755 --directory $RPM_BUILD_ROOT%{_var}/log/tendrl/ceph-integration
 install -m  0755  --directory $RPM_BUILD_ROOT%{_datadir}/tendrl/ceph-integration
+install -Dm 0644  etc/tendrl/ceph-integration/ceph-integration.conf.yaml.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/ceph-integration/ceph-integration.conf.yaml
+install -Dm 0644  etc/tendrl/ceph-integration/*.yaml.* $RPM_BUILD_ROOT%{_datadir}/tendrl/ceph-integration/.
+install -Dm 0644 etc/tendrl/ceph-integration/logging.yaml.timedrotation.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/ceph-integration_logging.yaml
 install -p -D -m 0644 systemd/tendrl-cephd.service $RPM_BUILD_ROOT%{_unitdir}/tendrl-cephd.service
-install -Dm 0644 etc/logging.yaml.timedrotation.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/ceph-integration_logging.yaml
-install -Dm 644 etc/*.sample $RPM_BUILD_ROOT%{_datadir}/tendrl/ceph-integration/.
 
 %post
 %systemd_post tendrl-cephd.service
@@ -57,13 +55,13 @@ py.test -v tendrl/ceph_integration/tests || :
 %files -f INSTALLED_FILES
 %dir %{_var}/log/tendrl/ceph-integration
 %dir %{_sysconfdir}/tendrl/ceph-integration
-%dir %{_datadir}/tendrl/ceph-integration
 %doc README.rst
 %license LICENSE
-%{_datadir}/tendrl/ceph-integration/
+%{_datadir}/tendrl/ceph-integration/.
 %{_unitdir}/tendrl-cephd.service
 %{_sysconfdir}/tendrl/ceph-integration_logging.yaml
+%{_sysconfdir}/tendrl/ceph-integration/ceph-integration.conf.yaml
 
 %changelog
-* Wed Oct 26 2016 Timothy Asir Jeyasingh <tjeyasin@redhat.com> - 0.0.1-1
+* Wed Oct 26 2016 Timothy Asir Jeyasingh <tjeyasin@redhat.com> - 1.1-1
 - Initial build.

--- a/tendrl/ceph_integration/__init__.py
+++ b/tendrl/ceph_integration/__init__.py
@@ -1,4 +1,3 @@
-__version__ = '1.2'
 try:
     from gevent import monkey
 except ImportError:


### PR DESCRIPTION
1) Update the make file and spec file to manage package version
from a common place

2) Update spec file with the recent changes in configuration files
like logging and etcd

tendrl-bug-id: Tendrl/ceph-integration#87
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>