### PR TITLE
Fix service start issue

### DIFF
--- a/systemd/tendrl-cephd.service
+++ b/systemd/tendrl-cephd.service
@@ -3,6 +3,7 @@ Description=Tendrl ceph integration to manage ceph storage system
 
 [Service]
 Type=simple
+Environment="HOME=/var/lib/tendrl"
 ExecStart=/usr/bin/tendrl-ceph-integration
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process


### PR DESCRIPTION
Set $HOME path to /var/lib/tendrl in service config file

tendrl-bug-id: Tendrl/ceph-integration#98
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>