### PR TITLE
Add a field called integration_name under TendrlContext

### DIFF
--- a/tendrl/ceph_integration/objects/definition/ceph.py
+++ b/tendrl/ceph_integration/objects/definition/ceph.py
@@ -407,6 +407,9 @@ namespace.tendrl.ceph_integration:
         integration_id:
           help: "Tendrl managed/generated cluster id for the sds being managed by Tendrl"
           type: String
+        integration_name:
+          help: "cluster name of the sds being managed by Tendrl"
+          type: String
         sds_name:
           help: gluster|ceph
           type: String

--- a/tendrl/ceph_integration/objects/tendrl_context/__init__.py
+++ b/tendrl/ceph_integration/objects/tendrl_context/__init__.py
@@ -20,7 +20,24 @@ class TendrlContext(objects.CephIntegrationBaseObject):
         self.integration_id = integration_id or self._get_local_integration_id()
         self.fsid = fsid or self._get_local_fsid()
         self.sds_name, self.sds_version = self._get_sds_details()
+        self.integration_name = self._get_integration_name()
         self._etcd_cls = _TendrlContextEtcd
+
+    def _get_integration_name(self):
+        cluster_name = ""
+        # TODO(team) This file is valid for CentOS and RHEL. Needs to
+        # be handled while ubuntu support is needed.
+        ceph_cfg_file = "/etc/sysconfig/ceph"
+        if not os.path.exists(ceph_cfg_file):
+            LOG.warning("config file: %s not found" % ceph_cfg_file)
+            return cluster_name
+
+        with open(ceph_cfg_file) as f:
+            for line in f:
+                if line.startswith("CLUSTER="):
+                    cluster_name = line.split('\n')[0].split('=')[1]
+                    break
+        return cluster_name
 
     def create_local_integration_id(self):
         tendrl_context_path = "/etc/tendrl/ceph-integration/integration_id"

--- a/tendrl/ceph_integration/objects/tendrl_context/__init__.py
+++ b/tendrl/ceph_integration/objects/tendrl_context/__init__.py
@@ -9,6 +9,7 @@ from tendrl.ceph_integration import objects
 
 LOG = logging.getLogger(__name__)
 
+DEFAULT_CEPH_CLUSTER_NAME = "ceph"
 
 class TendrlContext(objects.CephIntegrationBaseObject):
     def __init__(self, integration_id=None, fsid=None, *args, **kwargs):
@@ -24,7 +25,7 @@ class TendrlContext(objects.CephIntegrationBaseObject):
         self._etcd_cls = _TendrlContextEtcd
 
     def _get_integration_name(self):
-        cluster_name = ""
+        cluster_name = DEFAULT_CEPH_CLUSTER_NAME
         # TODO(team) This file is valid for CentOS and RHEL. Needs to
         # be handled while ubuntu support is needed.
         ceph_cfg_file = "/etc/sysconfig/ceph"
@@ -35,7 +36,7 @@ class TendrlContext(objects.CephIntegrationBaseObject):
         with open(ceph_cfg_file) as f:
             for line in f:
                 if line.startswith("CLUSTER="):
-                    cluster_name = line.split('\n')[0].split('=')[1]
+                    cluster_name = line.split('\n')[0].split('=')[-1]
                     break
         return cluster_name
 


### PR DESCRIPTION
This patch adds a new attr under TendrlContext called
integration_name which indicates the name of the underlying
ceph cluster.

tendrl-bug-id: Tendrl/ceph-integration#126
Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>