### PR TITLE
Added validations pre run for update pool update

### DIFF
--- a/tendrl/ceph_integration/__init__.py
+++ b/tendrl/ceph_integration/__init__.py
@@ -24,6 +24,8 @@ from tendrl.ceph_integration.objects.ecprofile.flows.delete_ec_profile import \
 from tendrl.ceph_integration.objects.pool.atoms.create import Create
 from tendrl.ceph_integration.objects.pool.atoms.delete import Delete
 from tendrl.ceph_integration.objects.pool.atoms.update import Update
+from tendrl.ceph_integration.objects.pool.atoms.valid_update_parameters \
+    import ValidUpdateParameters
 from tendrl.ceph_integration.objects.rbd.atoms.create import Create
 from tendrl.ceph_integration.objects.rbd.atoms.delete import Delete
 from tendrl.ceph_integration.objects.rbd.atoms.resize import Resize

--- a/tendrl/ceph_integration/objects/definition/ceph.py
+++ b/tendrl/ceph_integration/objects/definition/ceph.py
@@ -319,6 +319,24 @@ namespace.tendrl.ceph_integration:
           run: tendrl.ceph_integration.objects.Pool.atoms.update.Update
           type: Update
           uuid: 9a2df258-9b24-4fd3-a66f-ee346e2e3721
+        ValidUpdateParameters:
+          enabled: true
+          help: if update parametsr are valid
+          inputs:
+            mandatory:
+              - Pool.pool_id
+            optional:
+              - Pool.poolname
+              - Pool.size
+              - Pool.min_size
+              - Pool.pg_num
+              - Pool.quota_enabled
+              - Pool.quota_max_objects
+              - Pool.quota_max_bytes
+          name: Valid update parameters
+          run: tendrl.ceph_integration.objects.Pool.atoms.valid_update_parameters.ValidUpdateParameters
+          type: Get
+          uuid: 9a2df258-9b24-4fd3-a66f-ee346e2e3791
       flows:
         DeletePool:
           atoms:
@@ -350,6 +368,8 @@ namespace.tendrl.ceph_integration:
               - Pool.quota_enabled
               - Pool.quota_max_objects
               - Pool.quota_max_bytes
+          pre_run:
+            - tendrl.ceph_integration.objects.Pool.atoms.valid_update_parametsrs.ValidUpdateParameters
           run: tendrl.ceph_integration.objects.Pool.flows.update_pool.UpdatePool
           type: Update
           uuid: 4ac41d8f-a0cf-420a-b2fe-18761e07f3b2

--- a/tendrl/ceph_integration/objects/pool/atoms/create/__init__.py
+++ b/tendrl/ceph_integration/objects/pool/atoms/create/__init__.py
@@ -13,8 +13,8 @@ class Create(objects.CephIntegrationBaseAtom):
     def run(self):
         attrs = dict(name=self.parameters['Pool.poolname'],
                      pg_num=self.parameters['Pool.pg_num'],
-                     min_size=self.parameters['Pool.min_size'],
-                     size=self.parameters['Pool.size'],
+                     min_size=self.parameters.get('Pool.min_size'),
+                     size=self.parameters.get('Pool.size'),
                      type=self.parameters.get('Pool.type'),
                      erasure_code_profile=self.parameters.get(
                          'Pool.erasure_code_profile'))

--- a/tendrl/ceph_integration/objects/pool/atoms/valid_update_parameters/__init__.py
+++ b/tendrl/ceph_integration/objects/pool/atoms/valid_update_parameters/__init__.py
@@ -1,0 +1,71 @@
+from tendrl.ceph_integration import objects
+from tendrl.ceph_integration.objects.pool import Pool
+from tendrl.commons.event import Event
+from tendrl.commons.message import Message
+
+
+class ValidUpdateParameters(objects.CephIntegrationBaseAtom):
+    obj = Pool
+    def __init__(self, *args, **kwargs):
+        super(ValidUpdateParameters, self).__init__(*args, **kwargs)
+
+    def run(self):
+        Event(
+            Message(
+                priority="info",
+                publisher=tendrl_ns.publisher_id,
+                payload={
+                    "message": "Checking if update parameters are valid"
+                },
+                request_id=self.parameters['request_id'],
+                flow_id=self.parameters['flow_id'],
+                cluster_id=tendrl_ns.tendrl_context.integration_id,
+            )
+        )
+
+        if 'Pool.poolname' in self.parameters and \
+            ('Pool.pg_num' in self.parameters or
+             'Pool.size' in self.parameters or
+             'Pool.pg_num' in self.parameters or
+             'Pool.min_size' in self.parameters or
+             'Pool.quota_enabled' in self.parameters):
+            Event(
+                Message(
+                    priority="info",
+                    publisher=tendrl_ns.publisher_id,
+                    payload={
+                        "message": "Invalid combination of pool update parameters. "
+                        "Pool name shouldnt be updated with other parameters."
+                    },
+                    request_id=self.parameters['request_id'],
+                    flow_id=self.parameters['flow_id'],
+                    cluster_id=tendrl_ns.tendrl_context.integration_id,
+                )
+            )
+            raise AtomExecutionFailedError(
+                "Invalid combination of pool update parameters. "
+                "Pool name shoulnt be update with other parameters."
+            )
+
+        if 'Pool.pg_num' in self.parameters:
+            fetched_pool = Pool(
+                pool_id=self.parameters['Pool.pool_id']
+            ).load()
+            if self.parameters['Pool.pg_num'] <= fetched_pool.pg_num:
+                Event(
+                    Message(
+                        priority="info",
+                        publisher=tendrl_ns.publisher_id,
+                        payload={
+                            "message": "New pg-num cannot be less than existing value"
+                        },
+                        request_id=self.parameters['request_id'],
+                        flow_id=self.parameters['flow_id'],
+                        cluster_id=tendrl_ns.tendrl_context.integration_id,
+                    )
+                )
+                raise AtomExecutionFailedError(
+                    "New pg-num cannot be less than existing value"
+                )
+
+        return True


### PR DESCRIPTION
This validates if name and other parameters are getting updated
in same request.
Also adds a validation to not allow pg_num reduction as its not
allowed in ceph.

Signed-off-by: Shubhendu <shtripat@redhat.com>