### PR TITLE
Changes for resolving too many open fds issue.

### DIFF
--- a/tendrl/ceph_integration/objects/tendrl_context/__init__.py
+++ b/tendrl/ceph_integration/objects/tendrl_context/__init__.py
@@ -96,7 +96,8 @@ class TendrlContext(objects.CephIntegrationBaseObject):
             "ceph --version",
             shell=True,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            stderr=subprocess.PIPE,
+            close_fds=True
         )
         out, err = cmd.communicate()
         if err and 'command not found' in err:


### PR DESCRIPTION
This is required because after few hours of run, ceph-integration
starts leaking fds.
We need to close any sockets open for porcessing and pass close_fds while Popen calls.

tendrl-bug-id: Tendrl/ceph-integration#133
Signed-off-by: Shubhendu <shtripat@redhat.com>