### PR TITLE
fix for cluster_tendrl_context details are not populated correctly

### DIFF
--- a/tendrl/ceph_integration/manager/__init__.py
+++ b/tendrl/ceph_integration/manager/__init__.py
@@ -50,6 +50,13 @@ def main():
         NS.tendrl_context.cluster_name = "gluster-%s" % _detected_cluster.detected_cluster_id
         NS.tendrl_context.sds_name = _detected_cluster.sds_pkg_name
         NS.tendrl_context.sds_version = _detected_cluster.sds_pkg_version
+        NS.tendrl.objects.ClusterTendrlContext(
+            integration_id=NS.tendrl_context.integration_id,
+            cluster_id=NS.tendrl_context.cluster_id,
+            cluster_name=NS.tendrl_context.cluster_name,
+            sds_name=NS.tendrl_context.sds_name,
+            sds_version=NS.tendrl_context.sds_version
+        ).save()
 
     except etcd.EtcdKeyNotFound:
         LOG.error(


### PR DESCRIPTION
tendrl-bug-id: Tendrl/ceph-integration#176

Signd-off-by: root <root@dhcp42-67.lab.eng.blr.redhat.com>