### PR TITLE
Set default value for provisioned key in rbd sync

### DIFF
--- a/tendrl/ceph_integration/sds_sync/__init__.py
+++ b/tendrl/ceph_integration/sds_sync/__init__.py
@@ -137,7 +137,7 @@ class CephIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                     size=v['size'],
                     pool_id=pool_id,
                     flags=v['flags'],
-                    provisioned=self._to_bytes(v['provisioned']),
+                    provisioned=self._to_bytes(v.get("provisioned", 0)),
                     used=self._to_bytes(v['used'])
                 ).save()
 

--- a/tendrl/ceph_integration/sds_sync/__init__.py
+++ b/tendrl/ceph_integration/sds_sync/__init__.py
@@ -137,7 +137,8 @@ class CephIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                     size=v['size'],
                     pool_id=pool_id,
                     flags=v['flags'],
-                    provisioned=self._to_bytes(v.get("provisioned", 0)),
+                    provisioned=self._to_bytes(v['provisioned']) if v.get(
+                        "provisioned") else None,
                     used=self._to_bytes(v['used'])
                 ).save()
 


### PR DESCRIPTION
Though the issue could not be replicated, for a safe condition we can set the provisioned value to be None if it is not found during sync.

tendrl_issue_id: https://github.com/Tendrl/ceph-integration/issues/172
Signed-off-by: anmolsachan asachan@redhat.com