### PR TITLE
Added logic to save monitor key in central store

### DIFF
--- a/tendrl/ceph_integration/manager/__init__.py
+++ b/tendrl/ceph_integration/manager/__init__.py
@@ -102,7 +102,7 @@ def main():
             content = f.read()
             mon_sec = content.split('\n')[1].strip().split(' = ')[1].strip()
             NS.etcd_orm.client.write(
-                "clusters/%s/mon_key" % NS.tendrl_context.integration_id,
+                "clusters/%s/_mon_key" % NS.tendrl_context.integration_id,
                 mon_sec
             )
     except:


### PR DESCRIPTION
This monitor key is needed while expansion of the cluster by
adding new mon nodes.

Signed-off-by: Shubhendu <shtripat@redhat.com>