### PR TITLE
Removed saving of monitor key

### DIFF
--- a/tendrl/ceph_integration/manager/__init__.py
+++ b/tendrl/ceph_integration/manager/__init__.py
@@ -1,5 +1,4 @@
 import etcd
-import gevent
 import gevent.event
 import signal
 
@@ -88,33 +87,6 @@ def main():
 
     m = CephIntegrationManager()
     m.start()
-
-    # Persist the monitor secret to central store
-    # This is required while expand cluster with more mon nodes
-    # We need to wait for few seconds to let the first round of
-    # cluster sync happen
-    gevent.sleep(5)
-    try:
-        with open(
-            "/etc/ceph/%s.client.admin.keyring" %\
-            NS.tendrl_context.cluster_name
-        ) as f:
-            content = f.read()
-            mon_sec = content.split('\n')[1].strip().split(' = ')[1].strip()
-            NS.etcd_orm.client.write(
-                "clusters/%s/_mon_key" % NS.tendrl_context.integration_id,
-                mon_sec
-            )
-    except:
-        Event(
-            Message(
-                priority="warning",
-                publisher=NS.publisher_id,
-                payload={"message": "Couldn't save monitor key"}
-            )
-        )
-    finally:
-        f.close()
 
     complete = gevent.event.Event()
 

--- a/tendrl/ceph_integration/sds_sync/__init__.py
+++ b/tendrl/ceph_integration/sds_sync/__init__.py
@@ -250,7 +250,7 @@ class CephIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                 updated=now(), sync_type=sync_type.str,
                 version=new_object.version if isinstance(new_object.version,
                                                          int) else None,
-                when=now(), data=data['data']).save()
+                when=now(), data=data['data']).save(update=False)
 
             if sync_type.str == "health":
                 NS.ceph.objects.GlobalDetails(


### PR DESCRIPTION
As confirmed by ceph team, the keyring is not the actual
monitor secret to be used while expansion of cluster.

Rather we should save the monitor secret while cluster creation
flow and use the same in expansion time. Will send another PR
for saving the correct monitor secret as part of create cluster flow.

Signed-off-by: Shubhendu <shtripat@redhat.com>