### PR TITLE
Added logic to save monitor secret while start

### DIFF
--- a/tendrl/ceph_integration/sds_sync/__init__.py
+++ b/tendrl/ceph_integration/sds_sync/__init__.py
@@ -1,5 +1,6 @@
 import copy
 import datetime
+import etcd
 
 import gevent.event
 from pytz import utc
@@ -36,6 +37,7 @@ from tendrl.ceph_integration.util import now
 from tendrl.commons.event import Event
 from tendrl.commons.message import Message
 from tendrl.commons import sds_sync
+from tendrl.commons.utils import cmd_utils
 
 
 class CephIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
@@ -77,6 +79,36 @@ class CephIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
                 payload={"message": "%s running" % self.__class__.__name__}
             )
         )
+
+        # Check if monitor key exists, if not sync
+        try:
+            NS._int.client.read(
+                "clusters/%s/_mon_key" % NS.tendrl_context.integration_id
+            )
+        except etcd.EtcdKeyNotFound:
+            out, err, rc = cmd_utils.Command(
+                "ceph auth get mon. --cluster %s" %\
+                NS.tendrl_context.cluster_name
+            ).run()
+
+            if rc != 0:
+                Event(
+                    Message(
+                        priority="debug",
+                        publisher=NS.publisher_id,
+                        payload={
+                            "message": "Couldn't get monitor key. Error:%s " %\
+                            err
+                        }
+                    )
+                )
+            else:
+                if out and out != "":
+                    mon_sec = out.split('\n')[1].strip().split(' = ')[1].strip()
+                    NS._int.wclient.write(
+                        "clusters/%s/_mon_key" % NS.tendrl_context.integration_id,
+                        mon_sec
+                    )
 
         while not self._complete.is_set():
             gevent.sleep(10)


### PR DESCRIPTION
This is required for the case of pure import of a cluster
created outside of tendrl. In such a case we should figure out
and persist the monitor secret to central store, so that
further additions of mons to the cluster can utilize the
same value.

tendrl-node-id: Tendrl/ceph-integration#236
Signed-off-by: Shubhendu <shtripat@redhat.com>