### PR TITLE
Added alerting mechanism for OSD status/states

### DIFF
--- a/tendrl/ceph_integration/sds_sync/__init__.py
+++ b/tendrl/ceph_integration/sds_sync/__init__.py
@@ -62,6 +62,7 @@ class CephIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
 
     def _ping_cluster(self):
         NS.tendrl_context = NS.tendrl_context.load()
+        NS.node_context = NS.node_context.load()
         if NS.tendrl_context.cluster_id:
                 cluster_data = ceph.heartbeat(NS.tendrl_context.cluster_id)
                 NS.tendrl_context.cluster_id = self.fsid = cluster_data['fsid']
@@ -249,6 +250,9 @@ class CephIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
             crud.create("ec_profile", attrs)
 
     def _emit_event(self, severity, resource, curr_value, msg):
+        if not NS.node_context.node_id:
+            return
+        
         alert = {}
         alert['source'] = NS.publisher_id
         alert['pid'] = os.getpid()
@@ -265,8 +269,6 @@ class CephIntegrationSdsSyncStateThread(sds_sync.SdsSyncThread):
             fqdn=socket.getfqdn()
         )
         alert['node_id'] = NS.node_context.node_id
-        if not NS.node_context.node_id:
-            return
         Event(
             Message(
                 "notice",

--- a/tendrl/ceph_integration/types.py
+++ b/tendrl/ceph_integration/types.py
@@ -365,6 +365,21 @@ SYNC_OBJECT_STR_TYPE = dict((t.str, t) for t in SYNC_OBJECT_TYPES)
 USER_REQUEST_COMPLETE = 'complete'
 USER_REQUEST_SUBMITTED = 'submitted'
 
+# Severity codes for status
+CRITICAL = 1
+ERROR = 2
+WARNING = 3
+RECOVERY = 4
+INFO = 5
+
+SEVERITIES = {
+    CRITICAL: "CRITICAL",
+    ERROR: "ERROR",
+    WARNING: "WARNING",
+    RECOVERY: "RECOVERY",
+    INFO: "INFO"
+}
+
 # List of allowable things to send as ceph commands to OSDs
 OSD_IMPLEMENTED_COMMANDS = ('scrub', 'deep_scrub', 'repair')
 OSD_FLAGS = (


### PR DESCRIPTION
This PR has changes for syncing and lerting regarding other entities
like pools, cluster health and monitor status. Currently they are
commented and would be enabled at later stage as and when required.

tendrl-bug-id: Tendrl/ceph-integration#259
Signed-off-by: Shubhendu <shtripat@redhat.com>