### PR TITLE
Added the logic to wait for bigger time period while rbd creation

### DIFF
--- a/tendrl/ceph_integration/ceph.py
+++ b/tendrl/ceph_integration/ceph.py
@@ -418,9 +418,13 @@ def rbd_command(cluster_name, command_args, pool_name=None):
         stdin=open(os.devnull, "r"),
         close_fds=True
     )
-    if p.poll() is None:  # Force kill if process is still alive
-        gevent.sleep(2)
-        if p.poll() is None:
+    retry = 0
+    while True:
+        if p.poll() is not None:
+            break
+        gevent.sleep(0.5)
+        retry += 1
+        if retry > 60 and p.poll() is None:
             p.kill()
             return {'out': "", 'err': "rbd command timed out", 'status': 1}
 


### PR DESCRIPTION
Added the logic to wait for bigger time period while rbd creation
if executed.

The wait for 2 sec, while rbd creation is not enough. First time while
rbd creation, it takes little more time as there are few imports inside
function and with a fresh cluster the loading of modules might take
sometime.

Once the modules are loaded, this works fine. Changed the logic to wait
for 30 sec maximum and break as long as request is complete in other
cases.

tendrl-bug-id: Tendrl/ceph-integration#253
Signed-off-by: Shubhendu <shtripat@redhat.com>